### PR TITLE
Enable build and tests on Appveyor

### DIFF
--- a/YAXLibTests/SerializationTest.cs
+++ b/YAXLibTests/SerializationTest.cs
@@ -2198,6 +2198,7 @@ namespace YAXLibTests
             catch (Exception ex)
             {
                 var ser = new YAXSerializer(ex.GetType());
+                ser.MaxRecursion = 10; //todo with the default (300), this takes ages. Even now if 10 this is a really large string
                 string exceptionSerialized = ser.Serialize(ex);
                 Assert.That(exceptionSerialized, Is.Not.Empty);
             }

--- a/YAXLibTests/YAXLibTests.csproj
+++ b/YAXLibTests/YAXLibTests.csproj
@@ -25,12 +25,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ build_script:
 - ps: msbuild YAXLib.2015.sln /verbosity:minimal /t:rebuild /p:configuration=release
 
 test_script:
+  - dotnet test YAXLibTests
   - nuget.exe install OpenCover -ExcludeVersion
   - OpenCover\tools\OpenCover.Console.exe -register:user -target:"nunit3-console.exe" -targetargs:"\"c:\xaxlib\YAXLibTests\bin\Release\YAXLibTests.dll\" --result=myresults.xml;format=AppVeyor"  -returntargetcode -filter:"+[YAXLib]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -hideskipped:All -output:coverage.xml
   - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,15 @@
 clone_folder: c:\xaxlib
 version: 2.13.{build}
-configuration: Release
-build:
-  project: YAXLib.2013.sln
-  verbosity: minimal
+
+build_script:
+- ps: nuget restore YAXLib.2015.Core.sln -verbosity quiet
+- ps: msbuild YAXLib.2015.Core.sln /verbosity:minimal /t:rebuild /p:configuration=release
+- ps: nuget restore YAXLib.2015.sln -verbosity quiet
+- ps: msbuild YAXLib.2015.sln /verbosity:minimal /t:rebuild /p:configuration=release
+
 test_script:
   - nuget.exe install OpenCover -ExcludeVersion
-  - OpenCover\tools\OpenCover.Console.exe -register:user -target:"nunit-console.exe" -targetargs:"\"c:\xaxlib\YAXLibTests\bin\Release\YAXLibTests.dll\" -noshadow"  -returntargetcode -filter:"+[YAXLib]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -hideskipped:All -output:coverage.xml
+  - OpenCover\tools\OpenCover.Console.exe -register:user -target:"nunit3-console.exe" -targetargs:"\"c:\xaxlib\YAXLibTests\bin\Release\YAXLibTests.dll\" --result=myresults.xml;format=AppVeyor"  -returntargetcode -filter:"+[YAXLib]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -hideskipped:All -output:coverage.xml
   - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
   - pip install codecov
   - codecov -f "coverage.xml"


### PR DESCRIPTION
You can push on this branch.

.NET Core test fails
non .net Core test `SerializeExceptionShouldNotThrowExceptions ` is still slow (30sec)
as discussed here: https://github.com/sinairv/YAXLib/pull/57