### PR TITLE
Implemented IYaxMemberLevelAttribute and IYaxTypeLevelAttribute

### DIFF
--- a/YAXLib/Attributes/IYaxMemberAttribute.cs
+++ b/YAXLib/Attributes/IYaxMemberAttribute.cs
@@ -11,8 +11,9 @@ namespace YAXLib
     {
         /// <summary>
         /// The method is invoked by <see cref="MemberWrapper"/>.
+        /// Initial, attribute-specific properties for <see cref="MemberWrapper"/> will be set.
         /// </summary>
         /// <param name="memberWrapper"></param>
-        void Process (MemberWrapper memberWrapper);
+        void Setup (MemberWrapper memberWrapper);
     }
 }

--- a/YAXLib/Attributes/IYaxMemberAttribute.cs
+++ b/YAXLib/Attributes/IYaxMemberAttribute.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+namespace YAXLib
+{
+    /// <summary>
+    /// Attributes for members, that are process by <see cref="MemberWrapper"/>
+    /// must implement this interface.
+    /// </summary>
+    internal interface IYaxMemberAttribute
+    {
+        /// <summary>
+        /// The method is invoked by <see cref="MemberWrapper"/>.
+        /// </summary>
+        /// <param name="memberWrapper"></param>
+        void Process (MemberWrapper memberWrapper);
+    }
+}

--- a/YAXLib/Attributes/IYaxMemberLevelAttribute.cs
+++ b/YAXLib/Attributes/IYaxMemberLevelAttribute.cs
@@ -4,8 +4,7 @@
 namespace YAXLib
 {
     /// <summary>
-    /// Attributes for members, that are process by <see cref="MemberWrapper"/>
-    /// must implement this interface.
+    /// Attributes used on member-level must implement this interface.
     /// </summary>
     internal interface IYaxMemberLevelAttribute
     {

--- a/YAXLib/Attributes/IYaxMemberLevelAttribute.cs
+++ b/YAXLib/Attributes/IYaxMemberLevelAttribute.cs
@@ -7,7 +7,7 @@ namespace YAXLib
     /// Attributes for members, that are process by <see cref="MemberWrapper"/>
     /// must implement this interface.
     /// </summary>
-    internal interface IYaxMemberAttribute
+    internal interface IYaxMemberLevelAttribute
     {
         /// <summary>
         /// The method is invoked by <see cref="MemberWrapper"/>.

--- a/YAXLib/Attributes/IYaxTypeLevelAttribute.cs
+++ b/YAXLib/Attributes/IYaxTypeLevelAttribute.cs
@@ -4,8 +4,7 @@
 namespace YAXLib
 {
     /// <summary>
-    /// Attributes for members, that are process by <see cref="MemberWrapper"/>
-    /// must implement this interface.
+    /// Attributes used on type-level must implement this interface.
     /// </summary>
     internal interface IYaxTypeLevelAttribute
     {

--- a/YAXLib/Attributes/IYaxTypeLevelAttribute.cs
+++ b/YAXLib/Attributes/IYaxTypeLevelAttribute.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (C) Sina Iravanian, Julian Verdurmen, axuno gGmbH and other contributors.
+// Licensed under the MIT license.
+
+namespace YAXLib
+{
+    /// <summary>
+    /// Attributes for members, that are process by <see cref="MemberWrapper"/>
+    /// must implement this interface.
+    /// </summary>
+    internal interface IYaxTypeLevelAttribute
+    {
+        /// <summary>
+        /// The method is invoked by <see cref="UdtWrapper"/>.
+        /// Initial, attribute-specific properties for <see cref="UdtWrapper"/> will be set.
+        /// </summary>
+        /// <param name="udtWrapper"></param>
+        void Setup (UdtWrapper udtWrapper);
+    }
+}

--- a/YAXLib/Attributes/YAXAttributeForAttribute.cs
+++ b/YAXLib/Attributes/YAXAttributeForAttribute.cs
@@ -27,7 +27,7 @@ namespace YAXLib.Attributes
         public string Parent { get; set; }
 
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
         {
             if (memberWrapper.IsAllowedToProcess())
             {

--- a/YAXLib/Attributes/YAXAttributeForAttribute.cs
+++ b/YAXLib/Attributes/YAXAttributeForAttribute.cs
@@ -10,7 +10,7 @@ namespace YAXLib.Attributes
     ///     This attribute is applicable to fields and properties.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class YAXAttributeForAttribute : YAXBaseAttribute, IYaxMemberAttribute
+    public class YAXAttributeForAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXAttributeForAttribute" /> class.
@@ -27,7 +27,7 @@ namespace YAXLib.Attributes
         public string Parent { get; set; }
 
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
+        void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             if (memberWrapper.IsAllowedToProcess())
             {

--- a/YAXLib/Attributes/YAXAttributeForAttribute.cs
+++ b/YAXLib/Attributes/YAXAttributeForAttribute.cs
@@ -10,10 +10,8 @@ namespace YAXLib.Attributes
     ///     This attribute is applicable to fields and properties.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class YAXAttributeForAttribute : YAXBaseAttribute
+    public class YAXAttributeForAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
-        #region Constructors
-
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXAttributeForAttribute" /> class.
         /// </summary>
@@ -23,15 +21,24 @@ namespace YAXLib.Attributes
             Parent = parent;
         }
 
-        #endregion
-
-        #region Properties
-
         /// <summary>
         ///     Gets or sets the element of which the property becomes an attribute.
         /// </summary>
         public string Parent { get; set; }
 
-        #endregion
+        /// <inheritdoc/>
+        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        {
+            if (memberWrapper.IsAllowedToProcess())
+            {
+                memberWrapper.IsSerializedAsAttribute = true;
+                StringUtils.ExtractPathAndAliasFromLocationString(Parent,
+                    out var path, out var alias);
+
+                memberWrapper.SerializationLocation = path;
+                if (!string.IsNullOrEmpty(alias))
+                    memberWrapper.Alias = StringUtils.RefineSingleElement(alias);
+            }
+        }
     }
 }

--- a/YAXLib/Attributes/YAXAttributeForClassAttribute.cs
+++ b/YAXLib/Attributes/YAXAttributeForClassAttribute.cs
@@ -10,10 +10,10 @@ namespace YAXLib.Attributes
     ///     This attribute is applicable to fields and properties only.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class YAXAttributeForClassAttribute : YAXBaseAttribute, IYaxMemberAttribute
+    public class YAXAttributeForClassAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
     {
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
+        void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             if (memberWrapper.IsAllowedToProcess())
             {

--- a/YAXLib/Attributes/YAXAttributeForClassAttribute.cs
+++ b/YAXLib/Attributes/YAXAttributeForClassAttribute.cs
@@ -13,7 +13,7 @@ namespace YAXLib.Attributes
     public class YAXAttributeForClassAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
         {
             if (memberWrapper.IsAllowedToProcess())
             {

--- a/YAXLib/Attributes/YAXAttributeForClassAttribute.cs
+++ b/YAXLib/Attributes/YAXAttributeForClassAttribute.cs
@@ -10,7 +10,16 @@ namespace YAXLib.Attributes
     ///     This attribute is applicable to fields and properties only.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class YAXAttributeForClassAttribute : YAXBaseAttribute
+    public class YAXAttributeForClassAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
+        /// <inheritdoc/>
+        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        {
+            if (memberWrapper.IsAllowedToProcess())
+            {
+                memberWrapper.IsSerializedAsAttribute = true;
+                memberWrapper.SerializationLocation = ".";
+            }
+        }
     }
 }

--- a/YAXLib/Attributes/YAXBaseAttribute.cs
+++ b/YAXLib/Attributes/YAXBaseAttribute.cs
@@ -12,8 +12,4 @@ namespace YAXLib.Attributes
     public abstract class YAXBaseAttribute : Attribute
     {
     }
-
-    // TODO: rename to YAXContentFor in v3
-
-    // TODO: rename to YAXContentForClass in v3
 }

--- a/YAXLib/Attributes/YAXCollectionAttribute.cs
+++ b/YAXLib/Attributes/YAXCollectionAttribute.cs
@@ -12,10 +12,8 @@ namespace YAXLib.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class |
                     AttributeTargets.Struct)]
-    public class YAXCollectionAttribute : YAXBaseAttribute
+    public class YAXCollectionAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
-        #region Constructors
-
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXCollectionAttribute" /> class.
         /// </summary>
@@ -27,10 +25,6 @@ namespace YAXLib.Attributes
             EachElementName = null;
             IsWhiteSpaceSeparator = true;
         }
-
-        #endregion
-
-        #region Properties
 
         /// <summary>
         ///     Gets or sets the type of the serialization of the collection.
@@ -56,14 +50,18 @@ namespace YAXLib.Attributes
 
         /// <summary>
         ///     Gets or sets a value indicating whether white space characters are to be
-        ///     treated as sparators or not.
+        ///     treated as separators or not.
         /// </summary>
         /// <value>
         ///     <c>true</c> if white space separator characters are to be
-        ///     treated as sparators; otherwise, <c>false</c>.
+        ///     treated as separators; otherwise, <c>false</c>.
         /// </value>
         public bool IsWhiteSpaceSeparator { get; set; }
 
-        #endregion
+        /// <inheritdoc/>
+        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        {
+            memberWrapper.CollectionAttributeInstance = this;
+        }
     }
 }

--- a/YAXLib/Attributes/YAXCollectionAttribute.cs
+++ b/YAXLib/Attributes/YAXCollectionAttribute.cs
@@ -59,7 +59,7 @@ namespace YAXLib.Attributes
         public bool IsWhiteSpaceSeparator { get; set; }
 
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.CollectionAttributeInstance = this;
         }

--- a/YAXLib/Attributes/YAXCollectionAttribute.cs
+++ b/YAXLib/Attributes/YAXCollectionAttribute.cs
@@ -12,7 +12,7 @@ namespace YAXLib.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class |
                     AttributeTargets.Struct)]
-    public class YAXCollectionAttribute : YAXBaseAttribute, IYaxMemberAttribute
+    public class YAXCollectionAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXCollectionAttribute" /> class.
@@ -59,7 +59,7 @@ namespace YAXLib.Attributes
         public bool IsWhiteSpaceSeparator { get; set; }
 
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
+        void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.CollectionAttributeInstance = this;
         }

--- a/YAXLib/Attributes/YAXCollectionAttribute.cs
+++ b/YAXLib/Attributes/YAXCollectionAttribute.cs
@@ -12,7 +12,7 @@ namespace YAXLib.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class |
                     AttributeTargets.Struct)]
-    public class YAXCollectionAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
+    public class YAXCollectionAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute, IYaxTypeLevelAttribute
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXCollectionAttribute" /> class.
@@ -62,6 +62,12 @@ namespace YAXLib.Attributes
         void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.CollectionAttributeInstance = this;
+        }
+
+        /// <inheritdoc/>
+        void IYaxTypeLevelAttribute.Setup(UdtWrapper udtWrapper)
+        {
+            udtWrapper.CollectionAttributeInstance = this;
         }
     }
 }

--- a/YAXLib/Attributes/YAXCollectionItemTypeAttribute.cs
+++ b/YAXLib/Attributes/YAXCollectionItemTypeAttribute.cs
@@ -6,7 +6,7 @@ using System;
 namespace YAXLib.Attributes
 {
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = true)]
-    internal class YAXCollectionItemTypeAttribute : YAXBaseAttribute
+    internal class YAXCollectionItemTypeAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
         public YAXCollectionItemTypeAttribute(Type type)
         {
@@ -16,5 +16,11 @@ namespace YAXLib.Attributes
         public Type Type { get; }
 
         public string Alias { get; set; }
+
+        /// <inheritdoc/>
+        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        {
+            memberWrapper.AddAttributeToCollectionItemRealTypes(this);
+        }
     }
 }

--- a/YAXLib/Attributes/YAXCollectionItemTypeAttribute.cs
+++ b/YAXLib/Attributes/YAXCollectionItemTypeAttribute.cs
@@ -18,7 +18,7 @@ namespace YAXLib.Attributes
         public string Alias { get; set; }
 
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.AddAttributeToCollectionItemRealTypes(this);
         }

--- a/YAXLib/Attributes/YAXCollectionItemTypeAttribute.cs
+++ b/YAXLib/Attributes/YAXCollectionItemTypeAttribute.cs
@@ -6,7 +6,7 @@ using System;
 namespace YAXLib.Attributes
 {
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = true)]
-    internal class YAXCollectionItemTypeAttribute : YAXBaseAttribute, IYaxMemberAttribute
+    internal class YAXCollectionItemTypeAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
     {
         public YAXCollectionItemTypeAttribute(Type type)
         {
@@ -18,7 +18,7 @@ namespace YAXLib.Attributes
         public string Alias { get; set; }
 
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
+        void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.AddAttributeToCollectionItemRealTypes(this);
         }

--- a/YAXLib/Attributes/YAXCommentAttribute.cs
+++ b/YAXLib/Attributes/YAXCommentAttribute.cs
@@ -31,7 +31,7 @@ namespace YAXLib.Attributes
 
         
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
         {
             if (string.IsNullOrEmpty(Comment)) return;
 

--- a/YAXLib/Attributes/YAXCommentAttribute.cs
+++ b/YAXLib/Attributes/YAXCommentAttribute.cs
@@ -11,7 +11,7 @@ namespace YAXLib.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Field |
                     AttributeTargets.Property)]
-    public class YAXCommentAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
+    public class YAXCommentAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute, IYaxTypeLevelAttribute
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXCommentAttribute" /> class.
@@ -33,12 +33,23 @@ namespace YAXLib.Attributes
         /// <inheritdoc/>
         void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
-            if (string.IsNullOrEmpty(Comment)) return;
+            memberWrapper.Comment = GetComment();
+        }
+
+        /// <inheritdoc/>
+        void IYaxTypeLevelAttribute.Setup(UdtWrapper udtWrapper)
+        {
+            udtWrapper.Comment = GetComment();
+        }
+
+        private string[] GetComment()
+        {
+            if (string.IsNullOrEmpty(Comment)) return Array.Empty<string>();
 
             var comments = Comment!.Split(new[] {'\r', '\n'}, StringSplitOptions.RemoveEmptyEntries);
             for (var i = 0; i < comments.Length; i++) comments[i] = $" {comments[i].Trim()} ";
 
-            memberWrapper.Comment = comments;
+            return comments;
         }
     }
 }

--- a/YAXLib/Attributes/YAXCommentAttribute.cs
+++ b/YAXLib/Attributes/YAXCommentAttribute.cs
@@ -11,10 +11,8 @@ namespace YAXLib.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Field |
                     AttributeTargets.Property)]
-    public class YAXCommentAttribute : YAXBaseAttribute
+    public class YAXCommentAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
-        #region Constructors
-
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXCommentAttribute" /> class.
         /// </summary>
@@ -24,9 +22,6 @@ namespace YAXLib.Attributes
             Comment = comment;
         }
 
-        #endregion
-
-        #region Properties
 
         /// <summary>
         ///     Gets or sets the comment.
@@ -34,6 +29,16 @@ namespace YAXLib.Attributes
         /// <value>The comment.</value>
         public string Comment { get; set; }
 
-        #endregion
+        
+        /// <inheritdoc/>
+        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        {
+            if (string.IsNullOrEmpty(Comment)) return;
+
+            var comments = Comment!.Split(new[] {'\r', '\n'}, StringSplitOptions.RemoveEmptyEntries);
+            for (var i = 0; i < comments.Length; i++) comments[i] = $" {comments[i].Trim()} ";
+
+            memberWrapper.Comment = comments;
+        }
     }
 }

--- a/YAXLib/Attributes/YAXCommentAttribute.cs
+++ b/YAXLib/Attributes/YAXCommentAttribute.cs
@@ -11,7 +11,7 @@ namespace YAXLib.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Field |
                     AttributeTargets.Property)]
-    public class YAXCommentAttribute : YAXBaseAttribute, IYaxMemberAttribute
+    public class YAXCommentAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXCommentAttribute" /> class.
@@ -31,7 +31,7 @@ namespace YAXLib.Attributes
 
         
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
+        void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             if (string.IsNullOrEmpty(Comment)) return;
 

--- a/YAXLib/Attributes/YAXCustomSerializerAttribute.cs
+++ b/YAXLib/Attributes/YAXCustomSerializerAttribute.cs
@@ -13,7 +13,7 @@ namespace YAXLib.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class |
                     AttributeTargets.Struct)]
-    public class YAXCustomSerializerAttribute : YAXBaseAttribute, IYaxMemberAttribute
+    public class YAXCustomSerializerAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXCustomSerializerAttribute" /> class.
@@ -31,7 +31,7 @@ namespace YAXLib.Attributes
         public Type CustomSerializerType { get; }
 
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
+        void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             var isDesiredInterface =
                 ReflectionUtils.IsDerivedFromGenericInterfaceType(CustomSerializerType, typeof(ICustomSerializer<>),

--- a/YAXLib/Attributes/YAXCustomSerializerAttribute.cs
+++ b/YAXLib/Attributes/YAXCustomSerializerAttribute.cs
@@ -31,7 +31,7 @@ namespace YAXLib.Attributes
         public Type CustomSerializerType { get; }
 
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
         {
             var isDesiredInterface =
                 ReflectionUtils.IsDerivedFromGenericInterfaceType(CustomSerializerType, typeof(ICustomSerializer<>),

--- a/YAXLib/Attributes/YAXDictionaryAttribute.cs
+++ b/YAXLib/Attributes/YAXDictionaryAttribute.cs
@@ -91,7 +91,7 @@ namespace YAXLib.Attributes
         public string ValueFormatString { get; set; }
 
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.DictionaryAttributeInstance = this;
         }

--- a/YAXLib/Attributes/YAXDictionaryAttribute.cs
+++ b/YAXLib/Attributes/YAXDictionaryAttribute.cs
@@ -13,7 +13,7 @@ namespace YAXLib.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class |
                     AttributeTargets.Struct)]
-    public class YAXDictionaryAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
+    public class YAXDictionaryAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute, IYaxTypeLevelAttribute
     {
         private YAXNodeTypes _serializeKeyAs = YAXNodeTypes.Element;
         private YAXNodeTypes _serializeValueAs = YAXNodeTypes.Element;
@@ -94,6 +94,12 @@ namespace YAXLib.Attributes
         void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.DictionaryAttributeInstance = this;
+        }
+
+        /// <inheritdoc/>
+        void IYaxTypeLevelAttribute.Setup(UdtWrapper udtWrapper)
+        {
+            udtWrapper.DictionaryAttributeInstance = this;
         }
 
         private void CheckIntegrity()

--- a/YAXLib/Attributes/YAXDictionaryAttribute.cs
+++ b/YAXLib/Attributes/YAXDictionaryAttribute.cs
@@ -13,7 +13,7 @@ namespace YAXLib.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class |
                     AttributeTargets.Struct)]
-    public class YAXDictionaryAttribute : YAXBaseAttribute
+    public class YAXDictionaryAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
         private YAXNodeTypes _serializeKeyAs = YAXNodeTypes.Element;
         private YAXNodeTypes _serializeValueAs = YAXNodeTypes.Element;
@@ -89,6 +89,12 @@ namespace YAXLib.Attributes
         /// </summary>
         /// <value></value>
         public string ValueFormatString { get; set; }
+
+        /// <inheritdoc/>
+        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        {
+            memberWrapper.DictionaryAttributeInstance = this;
+        }
 
         private void CheckIntegrity()
         {

--- a/YAXLib/Attributes/YAXDictionaryAttribute.cs
+++ b/YAXLib/Attributes/YAXDictionaryAttribute.cs
@@ -13,7 +13,7 @@ namespace YAXLib.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class |
                     AttributeTargets.Struct)]
-    public class YAXDictionaryAttribute : YAXBaseAttribute, IYaxMemberAttribute
+    public class YAXDictionaryAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
     {
         private YAXNodeTypes _serializeKeyAs = YAXNodeTypes.Element;
         private YAXNodeTypes _serializeValueAs = YAXNodeTypes.Element;
@@ -91,7 +91,7 @@ namespace YAXLib.Attributes
         public string ValueFormatString { get; set; }
 
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
+        void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.DictionaryAttributeInstance = this;
         }

--- a/YAXLib/Attributes/YAXDontSerializeAttribute.cs
+++ b/YAXLib/Attributes/YAXDontSerializeAttribute.cs
@@ -10,10 +10,10 @@ namespace YAXLib.Attributes
     ///     This attribute is applicable to fields and properties.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class YAXDontSerializeAttribute : YAXBaseAttribute, IYaxMemberAttribute
+    public class YAXDontSerializeAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
     {
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
+        void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.IsAttributedAsDontSerialize = true;
         }

--- a/YAXLib/Attributes/YAXDontSerializeAttribute.cs
+++ b/YAXLib/Attributes/YAXDontSerializeAttribute.cs
@@ -13,7 +13,7 @@ namespace YAXLib.Attributes
     public class YAXDontSerializeAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.IsAttributedAsDontSerialize = true;
         }

--- a/YAXLib/Attributes/YAXDontSerializeAttribute.cs
+++ b/YAXLib/Attributes/YAXDontSerializeAttribute.cs
@@ -10,7 +10,12 @@ namespace YAXLib.Attributes
     ///     This attribute is applicable to fields and properties.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class YAXDontSerializeAttribute : YAXBaseAttribute
+    public class YAXDontSerializeAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
+        /// <inheritdoc/>
+        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        {
+            memberWrapper.IsAttributedAsDontSerialize = true;
+        }
     }
 }

--- a/YAXLib/Attributes/YAXDontSerializeIfNullAttribute.cs
+++ b/YAXLib/Attributes/YAXDontSerializeIfNullAttribute.cs
@@ -13,7 +13,7 @@ namespace YAXLib.Attributes
     public class YAXDontSerializeIfNullAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.IsAttributedAsDontSerializeIfNull = true;
         }

--- a/YAXLib/Attributes/YAXDontSerializeIfNullAttribute.cs
+++ b/YAXLib/Attributes/YAXDontSerializeIfNullAttribute.cs
@@ -10,7 +10,12 @@ namespace YAXLib.Attributes
     ///     This attribute is applicable to fields and properties.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class YAXDontSerializeIfNullAttribute : YAXBaseAttribute
+    public class YAXDontSerializeIfNullAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
+        /// <inheritdoc/>
+        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        {
+            memberWrapper.IsAttributedAsDontSerializeIfNull = true;
+        }
     }
 }

--- a/YAXLib/Attributes/YAXDontSerializeIfNullAttribute.cs
+++ b/YAXLib/Attributes/YAXDontSerializeIfNullAttribute.cs
@@ -10,10 +10,10 @@ namespace YAXLib.Attributes
     ///     This attribute is applicable to fields and properties.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class YAXDontSerializeIfNullAttribute : YAXBaseAttribute, IYaxMemberAttribute
+    public class YAXDontSerializeIfNullAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
     {
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
+        void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.IsAttributedAsDontSerializeIfNull = true;
         }

--- a/YAXLib/Attributes/YAXElementForAttribute.cs
+++ b/YAXLib/Attributes/YAXElementForAttribute.cs
@@ -28,7 +28,7 @@ namespace YAXLib.Attributes
         public string Parent { get; set; }
 
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.IsSerializedAsElement = true;
 

--- a/YAXLib/Attributes/YAXElementForAttribute.cs
+++ b/YAXLib/Attributes/YAXElementForAttribute.cs
@@ -10,7 +10,7 @@ namespace YAXLib.Attributes
     ///     for another element. This attribute is applicable to fields and properties.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class YAXElementForAttribute : YAXBaseAttribute, IYaxMemberAttribute
+    public class YAXElementForAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXElementForAttribute" /> class.
@@ -28,7 +28,7 @@ namespace YAXLib.Attributes
         public string Parent { get; set; }
 
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
+        void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.IsSerializedAsElement = true;
 

--- a/YAXLib/Attributes/YAXElementForAttribute.cs
+++ b/YAXLib/Attributes/YAXElementForAttribute.cs
@@ -10,10 +10,8 @@ namespace YAXLib.Attributes
     ///     for another element. This attribute is applicable to fields and properties.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class YAXElementForAttribute : YAXBaseAttribute
+    public class YAXElementForAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
-        #region Constructors
-
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXElementForAttribute" /> class.
         /// </summary>
@@ -23,16 +21,23 @@ namespace YAXLib.Attributes
             Parent = parent;
         }
 
-        #endregion
-
-        #region Properties
-
         /// <summary>
         ///     Gets or sets the element of which the property becomes a child element.
         /// </summary>
         /// <value>The element of which the property becomes a child element.</value>
         public string Parent { get; set; }
 
-        #endregion
+        /// <inheritdoc/>
+        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        {
+            memberWrapper.IsSerializedAsElement = true;
+
+            StringUtils.ExtractPathAndAliasFromLocationString(Parent, out var path,
+                out var alias);
+
+            memberWrapper.SerializationLocation = path;
+            if (!string.IsNullOrEmpty(alias))
+                memberWrapper.Alias = StringUtils.RefineSingleElement(alias);
+        }
     }
 }

--- a/YAXLib/Attributes/YAXElementOrder.cs
+++ b/YAXLib/Attributes/YAXElementOrder.cs
@@ -30,7 +30,7 @@ namespace YAXLib.Attributes
         public int Order { get; }
 
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.Order = Order;
         }

--- a/YAXLib/Attributes/YAXElementOrder.cs
+++ b/YAXLib/Attributes/YAXElementOrder.cs
@@ -9,10 +9,8 @@ namespace YAXLib.Attributes
     ///     Specifies the order upon which a field or property is serialized / deserialized.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class YAXElementOrder : YAXBaseAttribute
+    public class YAXElementOrder : YAXBaseAttribute, IYaxMemberAttribute
     {
-        #region Constructors
-
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXElementOrder" /> class.
         /// </summary>
@@ -26,15 +24,15 @@ namespace YAXLib.Attributes
             Order = order;
         }
 
-        #endregion
-
-        #region Properties
-
         /// <summary>
         ///     The order used to prioritize serialization and deserialization.
         /// </summary>
         public int Order { get; }
 
-        #endregion
+        /// <inheritdoc/>
+        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        {
+            memberWrapper.Order = Order;
+        }
     }
 }

--- a/YAXLib/Attributes/YAXElementOrder.cs
+++ b/YAXLib/Attributes/YAXElementOrder.cs
@@ -9,7 +9,7 @@ namespace YAXLib.Attributes
     ///     Specifies the order upon which a field or property is serialized / deserialized.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class YAXElementOrder : YAXBaseAttribute, IYaxMemberAttribute
+    public class YAXElementOrder : YAXBaseAttribute, IYaxMemberLevelAttribute
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXElementOrder" /> class.
@@ -30,7 +30,7 @@ namespace YAXLib.Attributes
         public int Order { get; }
 
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
+        void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.Order = Order;
         }

--- a/YAXLib/Attributes/YAXErrorIfMissedAttribute.cs
+++ b/YAXLib/Attributes/YAXErrorIfMissedAttribute.cs
@@ -39,7 +39,7 @@ namespace YAXLib.Attributes
         public object DefaultValue { get; set; }
 
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.TreatErrorsAs = TreatAs;
             memberWrapper.DefaultValue = DefaultValue;

--- a/YAXLib/Attributes/YAXErrorIfMissedAttribute.cs
+++ b/YAXLib/Attributes/YAXErrorIfMissedAttribute.cs
@@ -12,10 +12,8 @@ namespace YAXLib.Attributes
     ///     This attribute is applicable to fields and properties.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class YAXErrorIfMissedAttribute : YAXBaseAttribute
+    public class YAXErrorIfMissedAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
-        #region Constructors
-
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXErrorIfMissedAttribute" /> class.
         /// </summary>
@@ -25,10 +23,6 @@ namespace YAXLib.Attributes
             TreatAs = treatAs;
             DefaultValue = null;
         }
-
-        #endregion
-
-        #region Properties
 
         /// <summary>
         ///     Gets or sets the value indicating this situation is going to be treated as Error or Warning.
@@ -44,6 +38,11 @@ namespace YAXLib.Attributes
         /// <value>The default value.</value>
         public object DefaultValue { get; set; }
 
-        #endregion
+        /// <inheritdoc/>
+        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        {
+            memberWrapper.TreatErrorsAs = TreatAs;
+            memberWrapper.DefaultValue = DefaultValue;
+        }
     }
 }

--- a/YAXLib/Attributes/YAXErrorIfMissedAttribute.cs
+++ b/YAXLib/Attributes/YAXErrorIfMissedAttribute.cs
@@ -12,7 +12,7 @@ namespace YAXLib.Attributes
     ///     This attribute is applicable to fields and properties.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class YAXErrorIfMissedAttribute : YAXBaseAttribute, IYaxMemberAttribute
+    public class YAXErrorIfMissedAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXErrorIfMissedAttribute" /> class.
@@ -39,7 +39,7 @@ namespace YAXLib.Attributes
         public object DefaultValue { get; set; }
 
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
+        void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.TreatErrorsAs = TreatAs;
             memberWrapper.DefaultValue = DefaultValue;

--- a/YAXLib/Attributes/YAXFormatAttribute.cs
+++ b/YAXLib/Attributes/YAXFormatAttribute.cs
@@ -32,7 +32,7 @@ namespace YAXLib.Attributes
         public string Format { get; set; }
 
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.Format = Format;
         }

--- a/YAXLib/Attributes/YAXFormatAttribute.cs
+++ b/YAXLib/Attributes/YAXFormatAttribute.cs
@@ -13,10 +13,8 @@ namespace YAXLib.Attributes
     ///     This attribute is applicable to fields and properties.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class YAXFormatAttribute : YAXBaseAttribute
+    public class YAXFormatAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
-        #region Constructors
-
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXFormatAttribute" /> class.
         /// </summary>
@@ -26,10 +24,6 @@ namespace YAXLib.Attributes
             Format = format;
         }
 
-        #endregion
-
-        #region Properties
-
         /// <summary>
         ///     Gets or sets the format string needed to serialize data. The format string is the parameter
         ///     passed to the <c>ToString</c> method.
@@ -37,6 +31,10 @@ namespace YAXLib.Attributes
         /// <value></value>
         public string Format { get; set; }
 
-        #endregion
+        /// <inheritdoc/>
+        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        {
+            memberWrapper.Format = Format;
+        }
     }
 }

--- a/YAXLib/Attributes/YAXFormatAttribute.cs
+++ b/YAXLib/Attributes/YAXFormatAttribute.cs
@@ -13,7 +13,7 @@ namespace YAXLib.Attributes
     ///     This attribute is applicable to fields and properties.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class YAXFormatAttribute : YAXBaseAttribute, IYaxMemberAttribute
+    public class YAXFormatAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXFormatAttribute" /> class.
@@ -32,7 +32,7 @@ namespace YAXLib.Attributes
         public string Format { get; set; }
 
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
+        void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.Format = Format;
         }

--- a/YAXLib/Attributes/YAXNamespaceAttribute.cs
+++ b/YAXLib/Attributes/YAXNamespaceAttribute.cs
@@ -11,7 +11,7 @@ namespace YAXLib.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Field |
                     AttributeTargets.Property | AttributeTargets.Struct)]
-    public class YAXNamespaceAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
+    public class YAXNamespaceAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute, IYaxTypeLevelAttribute
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXNamespaceAttribute" /> class.
@@ -58,6 +58,13 @@ namespace YAXLib.Attributes
         {
             memberWrapper.Namespace = Namespace;
             memberWrapper.NamespacePrefix = Prefix;
+        }
+
+        /// <inheritdoc/>
+        void IYaxTypeLevelAttribute.Setup(UdtWrapper udtWrapper)
+        {
+            udtWrapper.Namespace = Namespace;
+            udtWrapper.NamespacePrefix = Prefix;
         }
     }
 }

--- a/YAXLib/Attributes/YAXNamespaceAttribute.cs
+++ b/YAXLib/Attributes/YAXNamespaceAttribute.cs
@@ -11,7 +11,7 @@ namespace YAXLib.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Field |
                     AttributeTargets.Property | AttributeTargets.Struct)]
-    public class YAXNamespaceAttribute : YAXBaseAttribute, IYaxMemberAttribute
+    public class YAXNamespaceAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXNamespaceAttribute" /> class.
@@ -54,7 +54,7 @@ namespace YAXLib.Attributes
         public string Prefix { get; }
 
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
+        void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.Namespace = Namespace;
             memberWrapper.NamespacePrefix = Prefix;

--- a/YAXLib/Attributes/YAXNamespaceAttribute.cs
+++ b/YAXLib/Attributes/YAXNamespaceAttribute.cs
@@ -54,7 +54,7 @@ namespace YAXLib.Attributes
         public string Prefix { get; }
 
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.Namespace = Namespace;
             memberWrapper.NamespacePrefix = Prefix;

--- a/YAXLib/Attributes/YAXNamespaceAttribute.cs
+++ b/YAXLib/Attributes/YAXNamespaceAttribute.cs
@@ -11,10 +11,8 @@ namespace YAXLib.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Field |
                     AttributeTargets.Property | AttributeTargets.Struct)]
-    public class YAXNamespaceAttribute : YAXBaseAttribute
+    public class YAXNamespaceAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
-        #region Constructors
-
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXNamespaceAttribute" /> class.
         /// </summary>
@@ -45,10 +43,6 @@ namespace YAXLib.Attributes
             Prefix = namespacePrefix;
         }
 
-        #endregion
-
-        #region Properties
-
         /// <summary>
         ///     The namespace path
         /// </summary>
@@ -59,6 +53,11 @@ namespace YAXLib.Attributes
         /// </summary>
         public string Prefix { get; }
 
-        #endregion
+        /// <inheritdoc/>
+        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        {
+            memberWrapper.Namespace = Namespace;
+            memberWrapper.NamespacePrefix = Prefix;
+        }
     }
 }

--- a/YAXLib/Attributes/YAXNotCollectionAttribute.cs
+++ b/YAXLib/Attributes/YAXNotCollectionAttribute.cs
@@ -12,10 +12,10 @@ namespace YAXLib.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class |
                     AttributeTargets.Struct)]
-    public class YAXNotCollectionAttribute : YAXBaseAttribute, IYaxMemberAttribute
+    public class YAXNotCollectionAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
     {
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
+        void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             // arrays are always treated as collections
             if (!ReflectionUtils.IsArray(memberWrapper.MemberType))

--- a/YAXLib/Attributes/YAXNotCollectionAttribute.cs
+++ b/YAXLib/Attributes/YAXNotCollectionAttribute.cs
@@ -12,7 +12,14 @@ namespace YAXLib.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class |
                     AttributeTargets.Struct)]
-    public class YAXNotCollectionAttribute : YAXBaseAttribute
+    public class YAXNotCollectionAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
+        /// <inheritdoc/>
+        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        {
+            // arrays are always treated as collections
+            if (!ReflectionUtils.IsArray(memberWrapper.MemberType))
+                memberWrapper.IsAttributedAsNotCollection = true;
+        }
     }
 }

--- a/YAXLib/Attributes/YAXNotCollectionAttribute.cs
+++ b/YAXLib/Attributes/YAXNotCollectionAttribute.cs
@@ -12,7 +12,7 @@ namespace YAXLib.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class |
                     AttributeTargets.Struct)]
-    public class YAXNotCollectionAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
+    public class YAXNotCollectionAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute, IYaxTypeLevelAttribute
     {
         /// <inheritdoc/>
         void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
@@ -20,6 +20,14 @@ namespace YAXLib.Attributes
             // arrays are always treated as collections
             if (!ReflectionUtils.IsArray(memberWrapper.MemberType))
                 memberWrapper.IsAttributedAsNotCollection = true;
+        }
+
+        /// <inheritdoc/>
+        void IYaxTypeLevelAttribute.Setup(UdtWrapper udtWrapper)
+        {
+            // arrays are always treated as collections
+            if (!ReflectionUtils.IsArray(udtWrapper.UnderlyingType))
+                udtWrapper.IsAttributedAsNotCollection = true;
         }
     }
 }

--- a/YAXLib/Attributes/YAXNotCollectionAttribute.cs
+++ b/YAXLib/Attributes/YAXNotCollectionAttribute.cs
@@ -15,7 +15,7 @@ namespace YAXLib.Attributes
     public class YAXNotCollectionAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
         {
             // arrays are always treated as collections
             if (!ReflectionUtils.IsArray(memberWrapper.MemberType))

--- a/YAXLib/Attributes/YAXPreserveWhitespaceAttribute.cs
+++ b/YAXLib/Attributes/YAXPreserveWhitespaceAttribute.cs
@@ -13,12 +13,18 @@ namespace YAXLib.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class |
                     AttributeTargets.Struct)]
-    public class YAXPreserveWhitespaceAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
+    public class YAXPreserveWhitespaceAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute, IYaxTypeLevelAttribute
     {
         /// <inheritdoc/>
         void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.PreservesWhitespace = true;
+        }
+
+        /// <inheritdoc/>
+        void IYaxTypeLevelAttribute.Setup(UdtWrapper udtWrapper)
+        {
+            udtWrapper.PreservesWhitespace = true;
         }
     }
 }

--- a/YAXLib/Attributes/YAXPreserveWhitespaceAttribute.cs
+++ b/YAXLib/Attributes/YAXPreserveWhitespaceAttribute.cs
@@ -13,10 +13,10 @@ namespace YAXLib.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class |
                     AttributeTargets.Struct)]
-    public class YAXPreserveWhitespaceAttribute : YAXBaseAttribute, IYaxMemberAttribute
+    public class YAXPreserveWhitespaceAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
     {
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
+        void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.PreservesWhitespace = true;
         }

--- a/YAXLib/Attributes/YAXPreserveWhitespaceAttribute.cs
+++ b/YAXLib/Attributes/YAXPreserveWhitespaceAttribute.cs
@@ -13,7 +13,12 @@ namespace YAXLib.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class |
                     AttributeTargets.Struct)]
-    public class YAXPreserveWhitespaceAttribute : YAXBaseAttribute
+    public class YAXPreserveWhitespaceAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
+        /// <inheritdoc/>
+        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        {
+            memberWrapper.PreservesWhitespace = true;
+        }
     }
 }

--- a/YAXLib/Attributes/YAXPreserveWhitespaceAttribute.cs
+++ b/YAXLib/Attributes/YAXPreserveWhitespaceAttribute.cs
@@ -16,7 +16,7 @@ namespace YAXLib.Attributes
     public class YAXPreserveWhitespaceAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.PreservesWhitespace = true;
         }

--- a/YAXLib/Attributes/YAXSerializableFieldAttribute.cs
+++ b/YAXLib/Attributes/YAXSerializableFieldAttribute.cs
@@ -15,7 +15,7 @@ namespace YAXLib.Attributes
     public class YAXSerializableFieldAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.IsAttributedAsSerializable = true;
         }

--- a/YAXLib/Attributes/YAXSerializableFieldAttribute.cs
+++ b/YAXLib/Attributes/YAXSerializableFieldAttribute.cs
@@ -12,10 +12,10 @@ namespace YAXLib.Attributes
     ///     This attribute is applicable to fields and properties.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class YAXSerializableFieldAttribute : YAXBaseAttribute, IYaxMemberAttribute
+    public class YAXSerializableFieldAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
     {
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
+        void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.IsAttributedAsSerializable = true;
         }

--- a/YAXLib/Attributes/YAXSerializableFieldAttribute.cs
+++ b/YAXLib/Attributes/YAXSerializableFieldAttribute.cs
@@ -12,7 +12,12 @@ namespace YAXLib.Attributes
     ///     This attribute is applicable to fields and properties.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class YAXSerializableFieldAttribute : YAXBaseAttribute
+    public class YAXSerializableFieldAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
+        /// <inheritdoc/>
+        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        {
+            memberWrapper.IsAttributedAsSerializable = true;
+        }
     }
 }

--- a/YAXLib/Attributes/YAXSerializableTypeAttribute.cs
+++ b/YAXLib/Attributes/YAXSerializableTypeAttribute.cs
@@ -12,10 +12,8 @@ namespace YAXLib.Attributes
     ///     This attribute is applicable to classes and structures.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
-    public class YAXSerializableTypeAttribute : YAXBaseAttribute
+    public class YAXSerializableTypeAttribute : YAXBaseAttribute, IYaxTypeLevelAttribute
     {
-        #region Constructors
-
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXSerializableTypeAttribute" /> class.
         /// </summary>
@@ -23,10 +21,6 @@ namespace YAXLib.Attributes
         {
             FieldsToSerialize = YAXSerializationFields.PublicPropertiesOnly;
         }
-
-        #endregion
-
-        #region Public Methods
 
         /// <summary>
         ///     Determines whether the serialization options property has been explicitly
@@ -41,10 +35,6 @@ namespace YAXLib.Attributes
             return _isOptionSet;
         }
 
-        #endregion
-
-        #region Private Fields
-
         /// <summary>
         ///     determines whether the serialization options property has been explicitly
         ///     set by the user.
@@ -55,10 +45,6 @@ namespace YAXLib.Attributes
         ///     Private variable to hold the serialization options
         /// </summary>
         private YAXSerializationOptions _serializationOptions = YAXSerializationOptions.SerializeNullObjects;
-
-        #endregion
-
-        #region Properties
 
         /// <summary>
         ///     Gets or sets the fields which YAXLib selects for serialization
@@ -81,6 +67,14 @@ namespace YAXLib.Attributes
             }
         }
 
-        #endregion
+        /// <inheritdoc/>
+        void IYaxTypeLevelAttribute.Setup(UdtWrapper udtWrapper)
+        {
+            udtWrapper.FieldsToSerialize = FieldsToSerialize;
+            if (IsSerializationOptionSet())
+            {
+                udtWrapper.SetSerializationOptionsFromAttribute(Options);
+            } 
+        }
     }
 }

--- a/YAXLib/Attributes/YAXSerializeAsAttribute.cs
+++ b/YAXLib/Attributes/YAXSerializeAsAttribute.cs
@@ -12,7 +12,7 @@ namespace YAXLib.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class |
                     AttributeTargets.Struct)]
-    public class YAXSerializeAsAttribute : YAXBaseAttribute, IYaxMemberAttribute
+    public class YAXSerializeAsAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXSerializeAsAttribute" /> class.
@@ -29,7 +29,7 @@ namespace YAXLib.Attributes
         public string SerializeAs { get; set; }
 
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
+        void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.Alias = StringUtils.RefineSingleElement(SerializeAs);
         }

--- a/YAXLib/Attributes/YAXSerializeAsAttribute.cs
+++ b/YAXLib/Attributes/YAXSerializeAsAttribute.cs
@@ -12,7 +12,7 @@ namespace YAXLib.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class |
                     AttributeTargets.Struct)]
-    public class YAXSerializeAsAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
+    public class YAXSerializeAsAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute, IYaxTypeLevelAttribute
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXSerializeAsAttribute" /> class.
@@ -32,6 +32,12 @@ namespace YAXLib.Attributes
         void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.Alias = StringUtils.RefineSingleElement(SerializeAs);
+        }
+
+        /// <inheritdoc/>
+        void IYaxTypeLevelAttribute.Setup(UdtWrapper udtWrapper)
+        {
+            udtWrapper.Alias = StringUtils.RefineSingleElement(SerializeAs);
         }
     }
 }

--- a/YAXLib/Attributes/YAXSerializeAsAttribute.cs
+++ b/YAXLib/Attributes/YAXSerializeAsAttribute.cs
@@ -12,10 +12,8 @@ namespace YAXLib.Attributes
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class |
                     AttributeTargets.Struct)]
-    public class YAXSerializeAsAttribute : YAXBaseAttribute
+    public class YAXSerializeAsAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
-        #region Constructors
-
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXSerializeAsAttribute" /> class.
         /// </summary>
@@ -25,15 +23,15 @@ namespace YAXLib.Attributes
             SerializeAs = serializeAs;
         }
 
-        #endregion
-
-        #region Properties
-
         /// <summary>
         ///     Gets or sets the alias for the property under which the property will be serialized.
         /// </summary>
         public string SerializeAs { get; set; }
 
-        #endregion
+        /// <inheritdoc/>
+        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        {
+            memberWrapper.Alias = StringUtils.RefineSingleElement(SerializeAs);
+        }
     }
 }

--- a/YAXLib/Attributes/YAXSerializeAsAttribute.cs
+++ b/YAXLib/Attributes/YAXSerializeAsAttribute.cs
@@ -29,7 +29,7 @@ namespace YAXLib.Attributes
         public string SerializeAs { get; set; }
 
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.Alias = StringUtils.RefineSingleElement(SerializeAs);
         }

--- a/YAXLib/Attributes/YAXTypeAttribute.cs
+++ b/YAXLib/Attributes/YAXTypeAttribute.cs
@@ -6,7 +6,7 @@ using System;
 namespace YAXLib.Attributes
 {
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = true)]
-    internal class YAXTypeAttribute : YAXBaseAttribute, IYaxMemberAttribute
+    internal class YAXTypeAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
     {
         public YAXTypeAttribute(Type type)
         {
@@ -18,7 +18,7 @@ namespace YAXLib.Attributes
         public string Alias { get; set; }
 
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
+        void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.AddAttributeToListOfRealTypes(this);
         }

--- a/YAXLib/Attributes/YAXTypeAttribute.cs
+++ b/YAXLib/Attributes/YAXTypeAttribute.cs
@@ -18,7 +18,7 @@ namespace YAXLib.Attributes
         public string Alias { get; set; }
 
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
         {
             memberWrapper.AddAttributeToListOfRealTypes(this);
         }

--- a/YAXLib/Attributes/YAXTypeAttribute.cs
+++ b/YAXLib/Attributes/YAXTypeAttribute.cs
@@ -6,7 +6,7 @@ using System;
 namespace YAXLib.Attributes
 {
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = true)]
-    internal class YAXTypeAttribute : YAXBaseAttribute
+    internal class YAXTypeAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
         public YAXTypeAttribute(Type type)
         {
@@ -16,5 +16,11 @@ namespace YAXLib.Attributes
         public Type Type { get; }
 
         public string Alias { get; set; }
+
+        /// <inheritdoc/>
+        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        {
+            memberWrapper.AddAttributeToListOfRealTypes(this);
+        }
     }
 }

--- a/YAXLib/Attributes/YAXValueForAttribute.cs
+++ b/YAXLib/Attributes/YAXValueForAttribute.cs
@@ -10,7 +10,7 @@ namespace YAXLib.Attributes
     ///     This attribute is applicable to fields and properties.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class YAXValueForAttribute : YAXBaseAttribute, IYaxMemberAttribute
+    public class YAXValueForAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXAttributeForAttribute" /> class.
@@ -27,7 +27,7 @@ namespace YAXLib.Attributes
         public string Parent { get; set; }
         
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
+        void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             if (memberWrapper.IsAllowedToProcess())            
             {

--- a/YAXLib/Attributes/YAXValueForAttribute.cs
+++ b/YAXLib/Attributes/YAXValueForAttribute.cs
@@ -10,10 +10,8 @@ namespace YAXLib.Attributes
     ///     This attribute is applicable to fields and properties.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class YAXValueForAttribute : YAXBaseAttribute
+    public class YAXValueForAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
-        #region Constructors
-
         /// <summary>
         ///     Initializes a new instance of the <see cref="YAXAttributeForAttribute" /> class.
         /// </summary>
@@ -23,15 +21,26 @@ namespace YAXLib.Attributes
             Parent = parent;
         }
 
-        #endregion
-
-        #region Properties
-
         /// <summary>
         ///     Gets or sets the element for which the property becomes a value.
         /// </summary>
         public string Parent { get; set; }
+        
+        /// <inheritdoc/>
+        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        {
+            if (memberWrapper.IsAllowedToProcess())            
+            {
+                memberWrapper.IsSerializedAsValue = true;
 
-        #endregion
+                StringUtils.ExtractPathAndAliasFromLocationString(Parent, out var path,
+                    out var alias);
+
+                memberWrapper.SerializationLocation = path;
+                if (!string.IsNullOrEmpty(alias))
+                    memberWrapper.Alias = StringUtils.RefineSingleElement(alias);
+            }
+        }
+        
     }
 }

--- a/YAXLib/Attributes/YAXValueForAttribute.cs
+++ b/YAXLib/Attributes/YAXValueForAttribute.cs
@@ -27,7 +27,7 @@ namespace YAXLib.Attributes
         public string Parent { get; set; }
         
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
         {
             if (memberWrapper.IsAllowedToProcess())            
             {

--- a/YAXLib/Attributes/YAXValueForClassAttribute.cs
+++ b/YAXLib/Attributes/YAXValueForClassAttribute.cs
@@ -10,10 +10,10 @@ namespace YAXLib.Attributes
     ///     This attribute is applicable to fields and properties.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class YAXValueForClassAttribute : YAXBaseAttribute, IYaxMemberAttribute
+    public class YAXValueForClassAttribute : YAXBaseAttribute, IYaxMemberLevelAttribute
     {
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
+        void IYaxMemberLevelAttribute.Setup(MemberWrapper memberWrapper)
         {
             if (memberWrapper.IsAllowedToProcess())            
             {

--- a/YAXLib/Attributes/YAXValueForClassAttribute.cs
+++ b/YAXLib/Attributes/YAXValueForClassAttribute.cs
@@ -13,7 +13,7 @@ namespace YAXLib.Attributes
     public class YAXValueForClassAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
         /// <inheritdoc/>
-        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        void IYaxMemberAttribute.Setup(MemberWrapper memberWrapper)
         {
             if (memberWrapper.IsAllowedToProcess())            
             {

--- a/YAXLib/Attributes/YAXValueForClassAttribute.cs
+++ b/YAXLib/Attributes/YAXValueForClassAttribute.cs
@@ -10,10 +10,16 @@ namespace YAXLib.Attributes
     ///     This attribute is applicable to fields and properties.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class YAXValueForClassAttribute : YAXBaseAttribute
+    public class YAXValueForClassAttribute : YAXBaseAttribute, IYaxMemberAttribute
     {
-        #region Constructors
-
-        #endregion
+        /// <inheritdoc/>
+        void IYaxMemberAttribute.Process(MemberWrapper memberWrapper)
+        {
+            if (memberWrapper.IsAllowedToProcess())            
+            {
+                memberWrapper.IsSerializedAsValue = true;
+                memberWrapper.SerializationLocation = ".";
+            }
+        }
     }
 }

--- a/YAXLib/EnumWrapper.cs
+++ b/YAXLib/EnumWrapper.cs
@@ -31,7 +31,7 @@ namespace YAXLib
         public EnumWrapper(Type t)
         {
             if (!t.IsEnum)
-                throw new ArithmeticException();
+                throw new ArgumentException($"The type of '{nameof(t)}' is not an Enum", nameof(t));
 
             _enumType = t;
 

--- a/YAXLib/MemberWrapper.cs
+++ b/YAXLib/MemberWrapper.cs
@@ -118,9 +118,6 @@ namespace YAXLib
 
                 if (attr is IYaxMemberLevelAttribute memberAttr)
                     memberAttr.Setup(this);
-                /*if (attr is YAXBaseAttribute)
-                    ProcessYaxAttribute(attr);*/
-
             }
 
             // now override some values from member-type-wrapper into member-wrapper

--- a/YAXLib/MemberWrapper.cs
+++ b/YAXLib/MemberWrapper.cs
@@ -135,7 +135,7 @@ namespace YAXLib
                 var customSerAttrs = Attribute.GetCustomAttributes(_memberInfo, attrType, true);
                 foreach (var attr in customSerAttrs)
                 {
-                    if (attr is IYaxMemberAttribute memberAttr)
+                    if (attr is IYaxMemberLevelAttribute memberAttr)
                         memberAttr.Setup(this);
                 }
             }
@@ -146,7 +146,7 @@ namespace YAXLib
                 if (attrsToProcessEarlier.Contains(attr.GetType()))
                     continue;
 
-                if (attr is IYaxMemberAttribute memberAttr)
+                if (attr is IYaxMemberLevelAttribute memberAttr)
                     memberAttr.Setup(this);
                 /*if (attr is YAXBaseAttribute)
                     ProcessYaxAttribute(attr);*/
@@ -618,7 +618,7 @@ namespace YAXLib
         }
 
         /// <summary>
-        /// Called by the following attributes implementing <see cref="IYaxMemberAttribute.Setup"/>:
+        /// Called by the following attributes implementing <see cref="IYaxMemberLevelAttribute.Setup"/>:
         /// <see cref="YAXAttributeForClassAttribute"/>, <see cref="YAXValueForClassAttribute"/>, <see cref="YAXAttributeForAttribute"/>
         /// <see cref="YAXValueForAttribute"/>.
         /// </summary>

--- a/YAXLib/MemberWrapper.cs
+++ b/YAXLib/MemberWrapper.cs
@@ -133,7 +133,11 @@ namespace YAXLib
             foreach (var attrType in attrsToProcessEarlier)
             {
                 var customSerAttrs = Attribute.GetCustomAttributes(_memberInfo, attrType, true);
-                foreach (var attr in customSerAttrs) ProcessYaxAttribute(attr);
+                foreach (var attr in customSerAttrs)
+                {
+                    if (attr is IYaxMemberAttribute memberAttr)
+                        memberAttr.Process(this);
+                }
             }
 
             foreach (var attr in Attribute.GetCustomAttributes(_memberInfo, true))
@@ -142,8 +146,11 @@ namespace YAXLib
                 if (attrsToProcessEarlier.Contains(attr.GetType()))
                     continue;
 
-                if (attr is YAXBaseAttribute)
-                    ProcessYaxAttribute(attr);
+                if (attr is IYaxMemberAttribute memberAttr)
+                    memberAttr.Process(this);
+                /*if (attr is YAXBaseAttribute)
+                    ProcessYaxAttribute(attr);*/
+
             }
 
             // now override some values from member-type-wrapper into member-wrapper
@@ -164,7 +171,7 @@ namespace YAXLib
         {
             get { return _alias; }
 
-            private set
+            internal set
             {
                 if (Namespace.IsEmpty())
                 {
@@ -211,19 +218,19 @@ namespace YAXLib
         ///     Gets an array of comment lines.
         /// </summary>
         /// <value>The comment lines.</value>
-        public string[]? Comment { get; private set; }
+        public string[]? Comment { get; internal set; }
 
         /// <summary>
         ///     Gets the default value for this instance.
         /// </summary>
         /// <value>The default value for this instance.</value>
-        public object? DefaultValue { get; private set; }
+        public object? DefaultValue { get; internal set; }
 
         /// <summary>
         ///     Gets the format specified for this value; <c>null</c> if no format is specified.
         /// </summary>
         /// <value>the format specified for this value; <c>null</c> if no format is specified.</value>
-        public string? Format { get; private set; }
+        public string? Format { get; internal set; }
 
         /// <summary>
         ///     Gets a value indicating whether this instance has comments.
@@ -249,7 +256,7 @@ namespace YAXLib
         /// <value>
         ///     <c>true</c> if this instance is attributed as dont serialize; otherwise, <c>false</c>.
         /// </value>
-        public bool IsAttributedAsDontSerialize { get; private set; }
+        public bool IsAttributedAsDontSerialize { get; internal set; }
 
         /// <summary>
         ///     Gets a value indicating whether this instance is attributed as not-collection.
@@ -257,7 +264,7 @@ namespace YAXLib
         /// <value>
         ///     <c>true</c> if this instance is attributed as not-collection; otherwise, <c>false</c>.
         /// </value>
-        public bool IsAttributedAsNotCollection { get; private set; }
+        public bool IsAttributedAsNotCollection { get; internal set; }
 
         /// <summary>
         ///     Gets a value indicating whether this instance is attributed as serializable.
@@ -265,15 +272,15 @@ namespace YAXLib
         /// <value>
         ///     <c>true</c> if this instance is attributed as serializable; otherwise, <c>false</c>.
         /// </value>
-        public bool IsAttributedAsSerializable { get; private set; }
+        public bool IsAttributedAsSerializable { get; internal set; }
 
         /// <summary>
         ///     Gets a value indicating whether this instance is attributed as dont serialize when null.
         /// </summary>
         /// <value>
-        ///     <c>true</c> if this instance is attributed as dont serialize when null; otherwise, <c>false</c>.
+        ///     <c>true</c> if this instance is attributed as don't serialize when null; otherwise, <c>false</c>.
         /// </value>
-        public bool IsAttributedAsDontSerializeIfNull { get; private set; }
+        public bool IsAttributedAsDontSerializeIfNull { get; internal set; }
 
         /// <summary>
         ///     Gets a value indicating whether this instance is serialized as an XML attribute.
@@ -285,7 +292,7 @@ namespace YAXLib
         {
             get { return _isSerializedAsAttribute; }
 
-            private set
+            internal set
             {
                 _isSerializedAsAttribute = value;
                 if (value)
@@ -304,7 +311,7 @@ namespace YAXLib
         {
             get { return _isSerializedAsValue; }
 
-            private set
+            internal set
             {
                 _isSerializedAsValue = value;
                 if (value)
@@ -324,7 +331,7 @@ namespace YAXLib
         {
             get { return !IsSerializedAsAttribute && !IsSerializedAsValue; }
 
-            private set
+            internal set
             {
                 if (value)
                 {
@@ -380,26 +387,34 @@ namespace YAXLib
         {
             get { return _serializationLocation; }
 
-            private set { _serializationLocation = StringUtils.RefineLocationString(value); }
+            internal set { _serializationLocation = StringUtils.RefineLocationString(value); }
         }
 
         /// <summary>
         ///     Gets the exception type for this instance in case of encountering missing values
         /// </summary>
         /// <value>The exception type for this instance in case of encountering missing values</value>
-        public YAXExceptionTypes TreatErrorsAs { get; private set; }
+        public YAXExceptionTypes TreatErrorsAs { get; internal set; }
 
         /// <summary>
         ///     Gets the collection attribute instance.
         /// </summary>
         /// <value>The collection attribute instance.</value>
-        public YAXCollectionAttribute? CollectionAttributeInstance => _collectionAttributeInstance;
+        public YAXCollectionAttribute? CollectionAttributeInstance
+        {
+            get => _collectionAttributeInstance;
+            internal set => _collectionAttributeInstance = value;
+        }
 
         /// <summary>
         ///     Gets the dictionary attribute instance.
         /// </summary>
         /// <value>The dictionary attribute instance.</value>
-        public YAXDictionaryAttribute? DictionaryAttributeInstance => _dictionaryAttributeInstance;
+        public YAXDictionaryAttribute? DictionaryAttributeInstance
+        {
+            get => _dictionaryAttributeInstance;
+            internal set => _dictionaryAttributeInstance = value;
+        }
 
         /// <summary>
         ///     Gets a value indicating whether this instance is treated as a collection.
@@ -421,7 +436,7 @@ namespace YAXLib
         ///     Gets or sets the type of the custom serializer.
         /// </summary>
         /// <value>The type of the custom serializer.</value>
-        public Type? CustomSerializerType { get; private set; }
+        public Type? CustomSerializerType { get; internal set; }
 
         /// <summary>
         ///     Gets a value indicating whether this instance has custom serializer.
@@ -431,9 +446,9 @@ namespace YAXLib
         /// </value>
         public bool HasCustomSerializer => CustomSerializerType != null;
 
-        public bool PreservesWhitespace { get; private set; }
+        public bool PreservesWhitespace { get; internal set; }
 
-        public int Order { get; private set; }
+        public int Order { get; internal set; }
 
         /// <summary>
         ///     Gets a value indicating whether this instance has a custom namespace
@@ -452,7 +467,7 @@ namespace YAXLib
         {
             get { return _namespace; }
 
-            private set
+            internal set
             {
                 _namespace = value;
                 // explicit namespace definition overrides namespace definitions in SerializeAs attributes.
@@ -474,7 +489,7 @@ namespace YAXLib
         ///     setting a default namespace for that element would make it apply to
         ///     the whole document).
         /// </remarks>
-        public string? NamespacePrefix { get; private set; }
+        public string? NamespacePrefix { get; internal set; }
 
         public bool IsRealTypeDefined(Type type)
         {
@@ -625,7 +640,7 @@ namespace YAXLib
             }
             else if (attr is YAXAttributeForClassAttribute)
             {
-                // it is required that YAXCustomSerializerAttribute is processed earlier
+                // MemberWrapper processes YAXCustomSerializerAttribute and YAXCollectionAttribute first
                 if (ReflectionUtils.IsBasicType(MemberType) || HasCustomSerializer || MemberTypeWrapper.HasCustomSerializer ||
                     _collectionAttributeInstance != null && _collectionAttributeInstance.SerializationType ==
                     YAXCollectionSerializationTypes.Serially)
@@ -636,7 +651,7 @@ namespace YAXLib
             }
             else if (attr is YAXValueForClassAttribute)
             {
-                // it is required that YAXCustomSerializerAttribute is processed earlier
+                // MemberWrapper processes YAXCustomSerializerAttribute and YAXCollectionAttribute first
                 if (ReflectionUtils.IsBasicType(MemberType) || HasCustomSerializer || MemberTypeWrapper.HasCustomSerializer ||
                     _collectionAttributeInstance != null && _collectionAttributeInstance.SerializationType ==
                     YAXCollectionSerializationTypes.Serially)
@@ -647,13 +662,13 @@ namespace YAXLib
             }
             else if (attr is YAXAttributeForAttribute forAttribute)
             {
-                // it is required that YAXCustomSerializerAttribute is processed earlier
+                // MemberWrapper processes YAXCustomSerializerAttribute and YAXCollectionAttribute first
                 if (ReflectionUtils.IsBasicType(MemberType) || HasCustomSerializer ||
                     _collectionAttributeInstance != null && _collectionAttributeInstance.SerializationType ==
                     YAXCollectionSerializationTypes.Serially)
                 {
                     IsSerializedAsAttribute = true;
-                    StringUtils.ExttractPathAndAliasFromLocationString(forAttribute.Parent,
+                    StringUtils.ExtractPathAndAliasFromLocationString(forAttribute.Parent,
                         out var path, out var alias);
 
                     SerializationLocation = path;
@@ -665,7 +680,7 @@ namespace YAXLib
             {
                 IsSerializedAsElement = true;
 
-                StringUtils.ExttractPathAndAliasFromLocationString(attribute.Parent, out var path,
+                StringUtils.ExtractPathAndAliasFromLocationString(attribute.Parent, out var path,
                     out var alias);
 
                 SerializationLocation = path;
@@ -674,14 +689,14 @@ namespace YAXLib
             }
             else if (attr is YAXValueForAttribute valueForAttribute)
             {
-                // it is required that YAXCustomSerializerAttribute is processed earlier
+                // MemberWrapper processes YAXCustomSerializerAttribute and YAXCollectionAttribute first
                 if (ReflectionUtils.IsBasicType(MemberType) || HasCustomSerializer ||
                     _collectionAttributeInstance != null && _collectionAttributeInstance.SerializationType ==
                     YAXCollectionSerializationTypes.Serially)
                 {
                     IsSerializedAsValue = true;
 
-                    StringUtils.ExttractPathAndAliasFromLocationString(valueForAttribute.Parent, out var path,
+                    StringUtils.ExtractPathAndAliasFromLocationString(valueForAttribute.Parent, out var path,
                         out var alias);
 
                     SerializationLocation = path;
@@ -765,21 +780,19 @@ namespace YAXLib
                 }
 
                 if (_possibleRealTypes.Any(x => x.Type == yaxTypeAttr?.Type))
-                    throw new YAXPolymorphicException(string.Format(
-                        "The type \"{0}\" for field/property \"{1}\" has already been defined through another attribute.",
-                        yaxTypeAttr?.Type.Name, _memberInfo));
+                    throw new YAXPolymorphicException(
+                        $"The type \"{yaxTypeAttr?.Type.Name}\" for field/property \"{_memberInfo}\" has already been defined through another attribute.");
 
                 if (alias != null && _possibleRealTypes.Any(x => alias.Equals(x.Alias, StringComparison.Ordinal)))
-                    throw new YAXPolymorphicException(string.Format(
-                        "The alias \"{0}\" given to type \"{1}\" for field/property \"{2}\" has already been given to another type through another attribute.",
-                        alias, yaxTypeAttr?.Type.Name, _memberInfo));
+                    throw new YAXPolymorphicException(
+                        $"The alias \"{alias}\" given to type \"{yaxTypeAttr?.Type.Name}\" for field/property \"{_memberInfo}\" has already been given to another type through another attribute.");
 
                 if (yaxTypeAttr != null) _possibleRealTypes.Add(yaxTypeAttr);
             }
             else if (attr is YAXCollectionItemTypeAttribute)
             {
-                var yaxColletionItemTypeAttr = attr as YAXCollectionItemTypeAttribute;
-                var alias = yaxColletionItemTypeAttr?.Alias;
+                var yaxCollectionItemTypeAttr = attr as YAXCollectionItemTypeAttribute;
+                var alias = yaxCollectionItemTypeAttr?.Alias;
                 if (alias != null)
                 {
                     alias = alias.Trim();
@@ -787,18 +800,18 @@ namespace YAXLib
                         alias = null;
                 }
 
-                if (_possibleCollectionItemRealTypes.Any(x => x.Type == yaxColletionItemTypeAttr?.Type))
+                if (_possibleCollectionItemRealTypes.Any(x => x.Type == yaxCollectionItemTypeAttr?.Type))
                     throw new YAXPolymorphicException(string.Format(
                         "The collection-item type \"{0}\" for collection \"{1}\" has already been defined through another attribute.",
-                        yaxColletionItemTypeAttr?.Type.Name, _memberInfo));
+                        yaxCollectionItemTypeAttr?.Type.Name, _memberInfo));
 
                 if (alias != null &&
                     _possibleCollectionItemRealTypes.Any(x => alias.Equals(x.Alias, StringComparison.Ordinal)))
                     throw new YAXPolymorphicException(string.Format(
                         "The alias \"{0}\" given to collection-item type \"{1}\" for field/property \"{2}\" has already been given to another type through another attribute.",
-                        alias, yaxColletionItemTypeAttr?.Type.Name, _memberInfo));
+                        alias, yaxCollectionItemTypeAttr?.Type.Name, _memberInfo));
 
-                if (yaxColletionItemTypeAttr != null) _possibleCollectionItemRealTypes.Add(yaxColletionItemTypeAttr);
+                if (yaxCollectionItemTypeAttr != null) _possibleCollectionItemRealTypes.Add(yaxCollectionItemTypeAttr);
             }
             else if (attr is YAXDontSerializeIfNullAttribute)
             {
@@ -812,6 +825,74 @@ namespace YAXLib
             {
                 throw new Exception("Added new attribute type to the library but not yet processed!");
             }
+        }
+
+        /// <summary>
+        /// Called by the following attributes implementing <see cref="IYaxMemberAttribute.Process(MemberWrapper)"/>:
+        /// <see cref="YAXAttributeForClassAttribute"/>, <see cref="YAXValueForClassAttribute"/>, <see cref="YAXAttributeForAttribute"/>
+        /// <see cref="YAXValueForAttribute"/>.
+        /// </summary>
+        /// <returns><see langword="true"/>, if processing is allowed.</returns>
+        /// <remarks>MemberWrapper processes YAXCustomSerializerAttribute and YAXCollectionAttribute first.</remarks>
+        internal bool IsAllowedToProcess()
+        {
+            return ReflectionUtils.IsBasicType(MemberType) || HasCustomSerializer || MemberTypeWrapper.HasCustomSerializer ||
+                   CollectionAttributeInstance is { SerializationType: YAXCollectionSerializationTypes.Serially };
+        }
+
+        /// <summary>
+        /// Adds the <paramref name="yaxTypeAttribute"/> to the list of possible real types.
+        /// </summary>
+        /// <param name="yaxTypeAttribute"></param>
+        /// <exception cref="YAXPolymorphicException"></exception>
+        internal void AddAttributeToListOfRealTypes(YAXTypeAttribute yaxTypeAttribute)
+        {
+            var alias = yaxTypeAttribute.Alias;
+            if (alias != null)
+            {
+                alias = alias.Trim();
+                if (alias.Length == 0)
+                    alias = null;
+            }
+
+            if (_possibleRealTypes.Any(x => x.Type == yaxTypeAttribute.Type))
+                throw new YAXPolymorphicException(
+                    $"The type \"{yaxTypeAttribute.Type.Name}\" for field/property \"{_memberInfo}\" has already been defined through another attribute.");
+
+            if (alias != null && _possibleRealTypes.Any(x => alias.Equals(x.Alias, StringComparison.Ordinal)))
+                throw new YAXPolymorphicException(
+                    $"The alias \"{alias}\" given to type \"{yaxTypeAttribute.Type.Name}\" for field/property \"{_memberInfo}\" has already been given to another type through another attribute.");
+
+            _possibleRealTypes.Add(yaxTypeAttribute);
+        }
+
+        /// <summary>
+        /// Adds the <paramref name="yaxCollectionItemTypeAttr"/> to the list of collection item real types.
+        /// </summary>
+        /// <param name="yaxCollectionItemTypeAttr"></param>
+        /// <exception cref="YAXPolymorphicException"></exception>
+        internal void AddAttributeToCollectionItemRealTypes(YAXCollectionItemTypeAttribute yaxCollectionItemTypeAttr)
+        {
+            var alias = yaxCollectionItemTypeAttr.Alias;
+            if (alias != null)
+            {
+                alias = alias.Trim();
+                if (alias.Length == 0)
+                    alias = null;
+            }
+
+            if (_possibleCollectionItemRealTypes.Any(x => x.Type == yaxCollectionItemTypeAttr.Type))
+                throw new YAXPolymorphicException(string.Format(
+                    "The collection-item type \"{0}\" for collection \"{1}\" has already been defined through another attribute.",
+                    yaxCollectionItemTypeAttr.Type.Name, _memberInfo));
+
+            if (alias != null &&
+                _possibleCollectionItemRealTypes.Any(x => alias.Equals(x.Alias, StringComparison.Ordinal)))
+                throw new YAXPolymorphicException(string.Format(
+                    "The alias \"{0}\" given to collection-item type \"{1}\" for field/property \"{2}\" has already been given to another type through another attribute.",
+                    alias, yaxCollectionItemTypeAttr.Type.Name, _memberInfo));
+
+            _possibleCollectionItemRealTypes.Add(yaxCollectionItemTypeAttr);
         }
     }
 }

--- a/YAXLib/StringUtils.cs
+++ b/YAXLib/StringUtils.cs
@@ -154,7 +154,7 @@ namespace YAXLib
         /// <param name="locationString">The location string.</param>
         /// <param name="path">The path to be extracted.</param>
         /// <param name="alias">The alias to be extracted.</param>
-        public static void ExttractPathAndAliasFromLocationString(string locationString, out string path,
+        public static void ExtractPathAndAliasFromLocationString(string locationString, out string path,
             out string alias)
         {
             var poundIndex = locationString.IndexOf('#');

--- a/YAXLib/UdtWrapper.cs
+++ b/YAXLib/UdtWrapper.cs
@@ -88,8 +88,7 @@ namespace YAXLib
             SetYAXSerializerOptions(callerSerializer);
             
             foreach (var attr in _udtType.GetCustomAttributes(true))
-                if (attr is YAXBaseAttribute)
-                    ProcessYAXAttribute(attr);
+                if (attr is IYaxTypeLevelAttribute typeLevelAttribute) typeLevelAttribute.Setup(this);
         }
 
         /// <summary>
@@ -100,7 +99,7 @@ namespace YAXLib
         {
             get { return _alias; }
 
-            private set
+            internal set
             {
                 if (Namespace.IsEmpty())
                 {
@@ -119,13 +118,13 @@ namespace YAXLib
         ///     Gets an array of comments for the underlying type.
         /// </summary>
         /// <value>The array of comments for the underlying type.</value>
-        public string[] Comment { get; private set; }
+        public string[] Comment { get; internal set; }
 
         /// <summary>
         ///     Gets the fields to be serialized.
         /// </summary>
         /// <value>The fields to be serialized.</value>
-        public YAXSerializationFields FieldsToSerialize { get; private set; }
+        public YAXSerializationFields FieldsToSerialize { get; internal set; }
 
         /// <summary>
         ///     Gets the serialization options.
@@ -139,7 +138,7 @@ namespace YAXLib
         /// <value>
         ///     <c>true</c> if this instance is attributed as not collection; otherwise, <c>false</c>.
         /// </value>
-        public bool IsAttributedAsNotCollection { get; private set; }
+        public bool IsAttributedAsNotCollection { get; internal set; }
 
         /// <summary>
         ///     Gets a value indicating whether this instance has comment.
@@ -252,19 +251,27 @@ namespace YAXLib
         ///     Gets the collection attribute instance.
         /// </summary>
         /// <value>The collection attribute instance.</value>
-        public YAXCollectionAttribute CollectionAttributeInstance => _collectionAttributeInstance;
+        public YAXCollectionAttribute CollectionAttributeInstance
+        {
+            get => _collectionAttributeInstance;
+            internal set => _collectionAttributeInstance = value;
+        }
 
         /// <summary>
         ///     Gets the dictionary attribute instance.
         /// </summary>
         /// <value>The dictionary attribute instance.</value>
-        public YAXDictionaryAttribute DictionaryAttributeInstance => _dictionaryAttributeInstance;
+        public YAXDictionaryAttribute DictionaryAttributeInstance
+        {
+            get => _dictionaryAttributeInstance;
+            internal set => _dictionaryAttributeInstance = value;
+        }
 
         /// <summary>
         ///     Gets or sets the type of the custom serializer.
         /// </summary>
         /// <value>The type of the custom serializer.</value>
-        public Type CustomSerializerType { get; private set; }
+        public Type CustomSerializerType { get; internal set; }
 
         /// <summary>
         ///     Gets a value indicating whether this instance has custom serializer.
@@ -274,7 +281,7 @@ namespace YAXLib
         /// </value>
         public bool HasCustomSerializer => CustomSerializerType != null;
 
-        public bool PreservesWhitespace { get; private set; }
+        public bool PreservesWhitespace { get; internal set; }
 
         /// <summary>
         ///     Gets a value indicating whether this instance has a custom namespace
@@ -293,7 +300,7 @@ namespace YAXLib
         {
             get { return _namespace; }
 
-            private set
+            internal set
             {
                 _namespace = value;
                 // explicit namespace definition overrides namespace definitions in SerializeAs attributes.
@@ -315,7 +322,7 @@ namespace YAXLib
         ///     setting a default namespace for that element would make it apply to
         ///     the whole document).
         /// </remarks>
-        public string NamespacePrefix { get; private set; }
+        public string NamespacePrefix { get; internal set; }
 
 
         /// <summary>
@@ -447,6 +454,16 @@ namespace YAXLib
             {
                 throw new Exception("Attribute not applicable to types!");
             }
+        }
+
+        /// <summary>
+        /// Used by attributes when setting <see cref="YAXSerializationOptions"/>.
+        /// </summary>
+        /// <param name="options"></param>
+        internal void SetSerializationOptionsFromAttribute(YAXSerializationOptions options)
+        {
+            SerializationOption = options;
+            _isSerializationOptionSetByAttribute = true;
         }
     }
 }

--- a/YAXLib/UdtWrapper.cs
+++ b/YAXLib/UdtWrapper.cs
@@ -5,7 +5,6 @@ using System;
 using System.Xml.Linq;
 using YAXLib.Attributes;
 using YAXLib.Enums;
-using YAXLib.Exceptions;
 
 namespace YAXLib
 {
@@ -380,80 +379,6 @@ namespace YAXLib
         public override int GetHashCode()
         {
             return _udtType.GetHashCode();
-        }
-
-        /// <summary>
-        ///     Processes the specified attribute.
-        /// </summary>
-        /// <param name="attr">The attribute to process.</param>
-        private void ProcessYAXAttribute(object attr)
-        {
-            if (attr is YAXCommentAttribute commentAttribute)
-            {
-                var comment = commentAttribute.Comment;
-                if (!string.IsNullOrEmpty(comment))
-                {
-                    var comments = comment.Split(new[] {'\r', '\n'}, StringSplitOptions.RemoveEmptyEntries);
-                    for (var i = 0; i < comments.Length; i++) comments[i] = string.Format(" {0} ", comments[i].Trim());
-
-                    Comment = comments;
-                }
-            }
-            else if (attr is YAXSerializableTypeAttribute theAttr)
-            {
-                FieldsToSerialize = theAttr.FieldsToSerialize;
-                if (theAttr.IsSerializationOptionSet())
-                {
-                    SerializationOption = theAttr.Options;
-                    _isSerializationOptionSetByAttribute = true;
-                }
-            }
-            else if (attr is YAXSerializeAsAttribute attribute)
-            {
-                Alias = StringUtils.RefineSingleElement(attribute.SerializeAs);
-            }
-            else if (attr is YAXNotCollectionAttribute)
-            {
-                if (!ReflectionUtils.IsArray(_udtType))
-                    IsAttributedAsNotCollection = true;
-            }
-            else if (attr is YAXCustomSerializerAttribute customSerializerAttribute)
-            {
-                var serType = customSerializerAttribute.CustomSerializerType;
-
-                var isDesiredSerializerInterface =
-                    ReflectionUtils.IsDerivedFromGenericInterfaceType(serType, typeof(ICustomSerializer<>),
-                        out var genTypeArg);
-
-                if (!isDesiredSerializerInterface)
-                    throw new YAXObjectTypeMismatch(typeof(ICustomSerializer<>), serType);
-                
-                if (!genTypeArg.IsAssignableFrom(UnderlyingType))
-                    throw new YAXObjectTypeMismatch(UnderlyingType, genTypeArg);
-
-                CustomSerializerType = serType;
-            }
-            else if (attr is YAXPreserveWhitespaceAttribute)
-            {
-                PreservesWhitespace = true;
-            }
-            else if (attr is YAXNamespaceAttribute nsAttrib)
-            {
-                Namespace = nsAttrib.Namespace;
-                NamespacePrefix = nsAttrib.Prefix;
-            }
-            else if (attr is YAXCollectionAttribute)
-            {
-                _collectionAttributeInstance = attr as YAXCollectionAttribute;
-            }
-            else if (attr is YAXDictionaryAttribute)
-            {
-                _dictionaryAttributeInstance = attr as YAXDictionaryAttribute;
-            }
-            else
-            {
-                throw new Exception("Attribute not applicable to types!");
-            }
         }
 
         /// <summary>

--- a/YAXLib/UdtWrapper.cs
+++ b/YAXLib/UdtWrapper.cs
@@ -112,7 +112,7 @@ namespace YAXLib
         ///     Gets the serialization options.
         /// </summary>
         /// <value>The serialization options.</value>
-        public YAXSerializationOptions SerializationOption { get; private set; }
+        public YAXSerializationOptions SerializationOptions { get; private set; }
 
         /// <summary>
         ///     Gets a value indicating whether this instance is attributed as not collection.
@@ -171,21 +171,21 @@ namespace YAXLib
         ///     <c>true</c> if serialization of null objects is not allowd; otherwise, <c>false</c>.
         /// </returns>
         public bool IsNotAllowedNullObjectSerialization =>
-            (SerializationOption & YAXSerializationOptions.DontSerializeNullObjects) ==
+            (SerializationOptions & YAXSerializationOptions.DontSerializeNullObjects) ==
             YAXSerializationOptions.DontSerializeNullObjects;
 
         /// <summary>
         ///     Determines whether cycling referrences must be ignored, or an exception needs to be thrown
         /// </summary>
         public bool ThrowUponSerializingCyclingReferences =>
-            (SerializationOption & YAXSerializationOptions.ThrowUponSerializingCyclingReferences) ==
+            (SerializationOptions & YAXSerializationOptions.ThrowUponSerializingCyclingReferences) ==
             YAXSerializationOptions.ThrowUponSerializingCyclingReferences;
 
         /// <summary>
         ///     Determines whether properties with no setters should be serialized
         /// </summary>
         public bool DoNotSerializePropertiesWithNoSetter =>
-            (SerializationOption & YAXSerializationOptions.DontSerializePropertiesWithNoSetter) ==
+            (SerializationOptions & YAXSerializationOptions.DontSerializePropertiesWithNoSetter) ==
             YAXSerializationOptions.DontSerializePropertiesWithNoSetter;
 
         /// <summary>
@@ -194,7 +194,7 @@ namespace YAXLib
         ///     Useful when generating XML intended for another system's consumption.
         /// </summary>
         public bool SuppressMetadataAttributes =>
-            (SerializationOption & YAXSerializationOptions.SuppressMetadataAttributes) ==
+            (SerializationOptions & YAXSerializationOptions.SuppressMetadataAttributes) ==
             YAXSerializationOptions.SuppressMetadataAttributes;
 
         /// <summary>
@@ -305,8 +305,8 @@ namespace YAXLib
         public void SetYAXSerializerOptions(YAXSerializer caller)
         {
             if (!_isSerializationOptionSetByAttribute)
-                SerializationOption = caller != null
-                    ? caller.SerializationOption
+                SerializationOptions = caller != null
+                    ? caller.Options.SerializationOptions
                     : YAXSerializationOptions.SerializeNullObjects;
         }
 
@@ -360,7 +360,7 @@ namespace YAXLib
         /// <param name="options"></param>
         internal void SetSerializationOptionsFromAttribute(YAXSerializationOptions options)
         {
-            SerializationOption = options;
+            SerializationOptions = options;
             _isSerializationOptionSetByAttribute = true;
         }
     }

--- a/YAXLib/UdtWrapper.cs
+++ b/YAXLib/UdtWrapper.cs
@@ -421,8 +421,6 @@ namespace YAXLib
                 if (!isDesiredSerializerInterface)
                     throw new YAXObjectTypeMismatch(typeof(ICustomSerializer<>), serType);
                 
-                // Reason for missing unit test coverage (?):
-                // Usually this case throws before
                 if (!genTypeArg.IsAssignableFrom(UnderlyingType))
                     throw new YAXObjectTypeMismatch(UnderlyingType, genTypeArg);
 

--- a/YAXLib/UdtWrapper.cs
+++ b/YAXLib/UdtWrapper.cs
@@ -14,16 +14,6 @@ namespace YAXLib
     internal class UdtWrapper
     {
         /// <summary>
-        ///     boolean value indicating whether this instance is a wrapper around a collection type
-        /// </summary>
-        private readonly bool _isTypeCollection;
-
-        /// <summary>
-        ///     boolean value indicating whether this instance is a wrapper around a dictionary type
-        /// </summary>
-        private readonly bool _isTypeDictionary;
-
-        /// <summary>
         ///     the underlying type for this instance of <c>TypeWrapper</c>
         /// </summary>
         private readonly Type _udtType;
@@ -32,16 +22,6 @@ namespace YAXLib
         ///     Alias for the type
         /// </summary>
         private XName _alias;
-
-        /// <summary>
-        ///     The collection attribute instance
-        /// </summary>
-        private YAXCollectionAttribute _collectionAttributeInstance;
-
-        /// <summary>
-        ///     the dictionary attribute instance
-        /// </summary>
-        private YAXDictionaryAttribute _dictionaryAttributeInstance;
 
         /// <summary>
         ///     reference to an instance of <c>EnumWrapper</c> in case that the current instance is an enum.
@@ -72,12 +52,12 @@ namespace YAXLib
         /// </param>
         public UdtWrapper(Type udtType, YAXSerializer callerSerializer)
         {
-            _isTypeDictionary = false;
+            IsDictionaryType = false;
             _udtType = ReflectionUtils.IsNullable(udtType, out var nullableUnderlyingType)
                 ? nullableUnderlyingType
                 : udtType;
-            _isTypeCollection = ReflectionUtils.IsCollectionType(_udtType);
-            _isTypeDictionary = ReflectionUtils.IsIDictionary(_udtType);
+            IsCollectionType = ReflectionUtils.IsCollectionType(_udtType);
+            IsDictionaryType = ReflectionUtils.IsIDictionary(_udtType);
 
             Alias = StringUtils.RefineSingleElement(ReflectionUtils.GetTypeFriendlyName(_udtType));
             Comment = null;
@@ -96,7 +76,10 @@ namespace YAXLib
         /// <value>The alias of the type.</value>
         public XName Alias
         {
-            get { return _alias; }
+            get
+            {
+                return _alias;
+            }
 
             internal set
             {
@@ -145,7 +128,7 @@ namespace YAXLib
         /// <value>
         ///     <c>true</c> if this instance has comment; otherwise, <c>false</c>.
         /// </value>
-        public bool HasComment => Comment != null && Comment.Length > 0;
+        public bool HasComment => Comment is { Length: > 0 };
 
         /// <summary>
         ///     Gets the underlying type corresponding to this wrapper.
@@ -220,7 +203,7 @@ namespace YAXLib
         /// <value>
         ///     <c>true</c> if this instance wraps around a collection type; otherwise, <c>false</c>.
         /// </value>
-        public bool IsCollectionType => _isTypeCollection;
+        public bool IsCollectionType { get; }
 
         /// <summary>
         ///     Gets a value indicating whether this instance wraps around a dictionary type.
@@ -228,7 +211,7 @@ namespace YAXLib
         /// <value>
         ///     <c>true</c> if this instance wraps around a dictionary type; otherwise, <c>false</c>.
         /// </value>
-        public bool IsDictionaryType => _isTypeDictionary;
+        public bool IsDictionaryType { get; }
 
         /// <summary>
         ///     Gets a value indicating whether this instance is treated as collection.
@@ -250,21 +233,13 @@ namespace YAXLib
         ///     Gets the collection attribute instance.
         /// </summary>
         /// <value>The collection attribute instance.</value>
-        public YAXCollectionAttribute CollectionAttributeInstance
-        {
-            get => _collectionAttributeInstance;
-            internal set => _collectionAttributeInstance = value;
-        }
+        public YAXCollectionAttribute CollectionAttributeInstance { get; internal set; }
 
         /// <summary>
         ///     Gets the dictionary attribute instance.
         /// </summary>
         /// <value>The dictionary attribute instance.</value>
-        public YAXDictionaryAttribute DictionaryAttributeInstance
-        {
-            get => _dictionaryAttributeInstance;
-            internal set => _dictionaryAttributeInstance = value;
-        }
+        public YAXDictionaryAttribute DictionaryAttributeInstance { get; internal set; }
 
         /// <summary>
         ///     Gets or sets the type of the custom serializer.
@@ -322,8 +297,7 @@ namespace YAXLib
         ///     the whole document).
         /// </remarks>
         public string NamespacePrefix { get; internal set; }
-
-
+        
         /// <summary>
         ///     Sets the serializer options.
         /// </summary>
@@ -361,10 +335,9 @@ namespace YAXLib
         /// </exception>
         public override bool Equals(object obj)
         {
-            if (obj is UdtWrapper)
+            if (obj is UdtWrapper udtWrapper)
             {
-                var other = obj as UdtWrapper;
-                return _udtType == other._udtType;
+                return _udtType == udtWrapper.UnderlyingType;
             }
 
             return false;

--- a/YAXLibTests/StringUtilsTest.cs
+++ b/YAXLibTests/StringUtilsTest.cs
@@ -62,7 +62,7 @@ namespace YAXLibTests
         private static void TestPathAndAlias(string locationString, string expectedPath, string expectedAlias)
         {
             string path, alias;
-            StringUtils.ExttractPathAndAliasFromLocationString(locationString, out path, out alias);
+            StringUtils.ExtractPathAndAliasFromLocationString(locationString, out path, out alias);
             Assert.That(path, Is.EqualTo(expectedPath));
             Assert.That(alias, Is.EqualTo(expectedAlias));
         }


### PR DESCRIPTION
* Created `IYaxMemberLevelAttribute`: implemented in `MemberWrapper` and existing attributes for members
* Created `IYaxTypeLevelAttribute`: implemented in `UdtWrapper` and existing attributes for types
* Moved code from `MemberWrapper.ProcessYAXAttribute(object attr)` to corresponding `IYaxMemberLevelAttribute.Setup(...)` of attributes
* Moved code from `UdtWrapper.ProcessYAXAttribute(object attr)` to corresponding `IYaxTypeLevelAttribute.Setup(...)` of attributes
* Most properties with backing fields are now auto-properties in `MemberWrapper` and `UdtWrapper`
* Fixed: `EnumWrapper(Type t)` now throws `ArgumentException`instead of wrong `ArithmeticException`
* Removed "TODO" comments
